### PR TITLE
Fix invalid mobility query

### DIFF
--- a/Master Filter
+++ b/Master Filter
@@ -65,7 +65,7 @@
   (basestat:discipline:>=13 basestat:intellect:>=13 basestat:strength:>=13))
   )
 
-  -(basestat:mobility:>= 8 basestat:resilience:>=8 basestat:recovery:>=8 basestat:discipline:>=8 basestat:intellect:>=8 basestat:strength:>=8)
+  -(basestat:mobility:>=8 basestat:resilience:>=8 basestat:recovery:>=8 basestat:discipline:>=8 basestat:intellect:>=8 basestat:strength:>=8)
   )
 
   or


### PR DESCRIPTION
I noticed that this had `basestat:mobility:>= 8` (note the space) which doesn't work.