### PR TITLE
Update Master Filter

### DIFF
--- a/Master Filter
+++ b/Master Filter
@@ -7,7 +7,7 @@ or
 
   -(is:titan (basestat:recovery:>=18 or basestat:total:>=63))
   -(is:hunter ((basestat:recovery:>=13 basestat:mobility:>=18) or basestat:recovery:>=18 or basestat:total:>=63))
-  -(is:warlock ((basestat:recovery:>=18 discipline:>=17) or basestat:recovery:>=18 or basestat:total:>=63))
+  -(is:warlock ((basestat:recovery:>=18 basestat:discipline:>=17) or basestat:recovery:>=18 or basestat:total:>=63))
 
   -(
   ((basestat:mobility:>=18 basestat:resilience:>=13) or


### PR DESCRIPTION
Fixes a typo - `discipline:` isn't a filter, but `basestat:discipline:` is.