### PR TITLE
Fixes favorite tag typo in weapon sorting

### DIFF
--- a/5. Hands On New Weapon Sorting
+++ b/5. Hands On New Weapon Sorting
@@ -1,1 +1,1 @@
-(is:weapon is:randomroll -is:inloadout -is:exotic -is:maxpower -tag:keep -tag:archive -tag: favorite)
+(is:weapon is:randomroll -is:inloadout -is:exotic -is:maxpower -tag:keep -tag:archive -tag:favorite)


### PR DESCRIPTION
I tried this and saw favorited weapons highlighted due to the filter typo.