### PR TITLE
Simplify average searches

### DIFF
--- a/2. Searches/Vault Analyzer.txt
+++ b/2. Searches/Vault Analyzer.txt
@@ -1,86 +1,26 @@
-("TMMania's Vault Analyzer | Highlights Trash |
-Update Version: August 18th, 2021"
-or
+("TMMania's Vault Analyzer | Highlights Trash | Update Version: October 5th, 2021") or
 (
-(
-	(
-	is:weapon (is:sunset or is:blue)
-	)
-or
-  (
-	(is:armor -is:exotic -is:classitem)
-
-	-(source:raid -is:dupelower -source:dcv)
-
-	-(maxbasestatvalue:any)
-	-(basestat:any:>=23)
-	-(basestat:total:>=65)
-
-	-(((basestat:mobility&resilience:>=17.5) or
-	(basestat:mobility&recovery:>=17.5) or
-	(basestat:mobility&discipline:>=17.5) or
-	(basestat:mobility&intellect:>=17.5) or
-	(basestat:mobility&strength:>=17.5) or
-	(basestat:resilience&recovery:>=17.5) or
-	(basestat:resilience&discipline:>=17.5) or
-	(basestat:resilience&intellect:>=17.5) or
-	(basestat:resilience&strength:>=17.5) or
-	(basestat:recovery&discipline:>=17.5) or
-	(basestat:recovery&intellect:>=17.5) or
-	(basestat:recovery&strength:>=17.5) or
-	(basestat:discipline&intellect:>=17.5) or
-	(basestat:discipline&strength:>=17.5) or
-	(basestat:intellect&strength:>=17.5)) -basestat:secondhighest:<15)
-
-	-(((basestat:mobility&resilience&recovery:>=15) or
-	(basestat:mobility&resilience&discipline:>=15) or
-	(basestat:mobility&resilience&intellect:>=15) or
-	(basestat:mobility&resilience&strength:>=15) or
-	(basestat:mobility&recovery&discipline:>=15) or
-	(basestat:mobility&recovery&intellect:>=15) or
-	(basestat:mobility&recovery&strength:>=15) or
-	(basestat:mobility&discipline&intellect:>=15) or
-	(basestat:mobility&discipline&strength:>=15) or
-	(basestat:mobility&intellect&strength:>=15) or
-	(basestat:resilience&recovery&discipline:>=15) or
-	(basestat:resilience&recovery&intellect:>=15) or
-	(basestat:resilience&recovery&strength:>=15) or
-	(basestat:resilience&discipline&intellect:>=15) or
-	(basestat:resilience&discipline&strength:>=15) or
-	(basestat:resilience&intellect&strength:>=15) or
-	(basestat:recovery&discipline&intellect:>=15) or
-	(basestat:recovery&discipline&strength:>=15) or
-	(basestat:recovery&intellect&strength:>=15) or
-	(basestat:discipline&intellect&strength:>=15)) -basestat:thirdhighest:<11)
-
-	-(((basestat:mobility&resilience&recovery&intellect:>=13.25) or
-	(basestat:mobility&resilience&recovery&discipline:>=13.25) or
-	(basestat:mobility&resilience&recovery&strength:>=13.25) or
-	(basestat:mobility&resilience&intellect&discipline:>=13.25) or
-	(basestat:mobility&resilience&intellect&strength:>=13.25) or
-	(basestat:mobility&resilience&discipline&strength:>=13.25) or
-	(basestat:mobility&recovery&intellect&discipline:>=13.25) or
-	(basestat:mobility&recovery&intellect&strength:>=13.25) or
-	(basestat:mobility&recovery&discipline&strength:>=13.25) or
-	(basestat:mobility&intellect&discipline&strength:>=13.25) or
-	(basestat:resilience&recovery&intellect&discipline:>=13.25) or
-	(basestat:resilience&recovery&intellect&strength:>=13.25) or
-	(basestat:resilience&recovery&discipline&strength:>=13.25) or
-	(basestat:resilience&intellect&discipline&strength:>=13.25) or
-	(basestat:recovery&intellect&discipline&strength:>=13.25)) -basestat:fourthhighest:<10)
-
-	-(basestat:mobility&resilience&recovery&discipline&intellect&strength:>=9 basestat:sixthhighest:>5 basestat:highest:<16)
-  )
-
-or
-	(is:classitem energycapacity:<=5 -is:modded -is:locked -(source:raid -is:dupelower -source:dcv))
-or
-	(is:armor is:sunset)
-or
-	(is:armor is:blue -(name:"war mantis" is:gauntlets))	
-or
-	((is:armor or is:weapon) and (is:common or is:uncommon))
-)
--(is:tagged -tag:junk) -is:maxpower -power:pinnaclecap -is:inloadout -is:masterwork -(is:armor -is:armor2.0) -(is:armor source:events)
-)  or (tag:junk -is:maxpower)
+    (
+        is:haspower (is:sunset or is:blue or is:common or is:uncommon)
+    ) or (
+        is:armor -is:exotic -is:classitem
+        -maxbasestatvalue:any -basestat:any:>=23 -basestat:total:>=65
+        -(basestat:highest&secondhighest:>=17.5 -basestat:secondhighest:<15)
+        -(basestat:highest&secondhighest&thirdhighest:>=15 -basestat:thirdhighest:<11)
+        -(basestat:highest&secondhighest&thirdhighest&fourthhighest:>=13.25 -basestat:fourthhighest:<10)
+        -(basestat:mobility&resilience&recovery&discipline&intellect&strength:>=9 basestat:sixthhighest:>5 basestat:highest:<16)
+    ) or (
+        is:classitem energycapacity:<=5 -is:modded -is:locked
+    )
+    -(name:"war mantis" is:gauntlets)
+    -(source:raid -is:dupelower -source:dcv)
+    -(is:tagged -tag:junk)
+    -is:maxpower
+    -power:pinnaclecap
+    -is:inloadout
+    -is:masterwork
+    -(is:armor -is:armor2.0)
+    -(is:armor source:events)
+) or (
+    tag:junk -is:maxpower
 )


### PR DESCRIPTION
This pull request uses DIM's placeholders for stat names, avoiding typing all the possible permutations when doing the average searches for armor stats.

For example, instead of writing 15 permutations:
```
(basestat:mobility&resilience:>=17.5) or
(basestat:mobility&recovery:>=17.5) or
(basestat:mobility&discipline:>=17.5) or
............
```
I can write just once:
```
basestat:highest&secondhighest:>=17.5
```

Also, I moved `-(source:raid -is:dupelower -source:dcv)` in order to avoid repeating it for class items.

Hope you find this useful, anyway thanks a lot for your work!

PS I tested this in DIM, and it gives the same results as yours. However you may want to test it yourself.